### PR TITLE
Create CI pipeline that builds and runs CBC-optimizer tests

### DIFF
--- a/.github/workflows/cbc-optimizer-ci.yml
+++ b/.github/workflows/cbc-optimizer-ci.yml
@@ -14,66 +14,10 @@ defaults:
 jobs:
   build:
     name: Build tool
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - 'ubuntu-latest'
-          - 'macos-latest'
-          - 'windows-latest'
-        python-version:
-          - '3.7'
-          - '3.8'
-          - '3.9'
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2.4.0
-      - name: Setup Python
-        uses: actions/setup-python@v2.3.0
-        with:
-          python-version: ${{matrix.python-version}}
-
-      # Create cache so that we don't have to do this for each step in the matrix.
-      - name: Create cache for Poetry
-        id: cache-poetry
-        uses: actions/cache@v2.1.6
-        with:
-          path: ~/.poetry
-          key: ${{ matrix.os }}-poetry
-
-      # Install latest Poetry if cache has changed.
-      - name: Install latest version of Poetry
-        if: steps.cache-poetry.outputs.cache-hit != 'true'
-        run: |
-          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
-
-      # Add Poetry to github_path
-      - name: Add Poetry to $PATH
-        run: |
-          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
-
-      - name: Get Poetry version
-        run: poetry --version
-
-      - name: Check pyproject.toml validity
-        run: poetry check --no-interaction
-
-      - name: Cache dependencies
-        id: cache-deps
-        uses: actions/cache@v2.1.6
-        with:
-          path: ${{github.workspace}}/.venv
-          key: ${{ matrix.os }}-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: ${{ matrix.os }}-
-
-      - name: Install deps
-        if: steps.cache-deps.cache-hit != 'true'
-        run: |
-          poetry config virtualenvs.in-project true
-          poetry install --no-interaction
-
-      - name: Run tests
-        run: poetry run pytest -v
-
-      - name: Build artifacts
-        run: poetry build
+      - uses: actions/checkout@v2
+      - name: Build libraries
+        run: docker build --pull -t oogeso --target dev -f Dockerfile .
+      - name: Test Oogeso including cbc
+        run: docker run --rm -c "poetry run pytest"

--- a/.github/workflows/cbc-optimizer-ci.yml
+++ b/.github/workflows/cbc-optimizer-ci.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build libraries
+      - name: Build Dockerfile
         run: docker build --pull -t oogeso --target dev -f Dockerfile .
-      - name: Test Oogeso including cbc
-        run: docker run --rm -c "poetry run pytest"
+      - name: Test cbc
+        run: docker run --rm -c "poetry run pytest tests/test_cbc.py"

--- a/.github/workflows/cbc-optimizer-ci.yml
+++ b/.github/workflows/cbc-optimizer-ci.yml
@@ -20,4 +20,4 @@ jobs:
       - name: Build Dockerfile
         run: docker build --pull -t oogeso --target dev -f Dockerfile .
       - name: Test cbc
-        run: docker run --rm -c "poetry run pytest tests/test_cbc.py"
+        run: docker run --rm oogeso bash -c "poetry run pytest"

--- a/.github/workflows/cbc-optimizer-ci.yml
+++ b/.github/workflows/cbc-optimizer-ci.yml
@@ -1,4 +1,4 @@
-name: Build
+name: CBC-optimizer CI
 
 on:
   push:

--- a/.github/workflows/cbc-optimizer-ci.yml
+++ b/.github/workflows/cbc-optimizer-ci.yml
@@ -1,0 +1,79 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    name: Build tool
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - 'ubuntu-latest'
+          - 'macos-latest'
+          - 'windows-latest'
+        python-version:
+          - '3.7'
+          - '3.8'
+          - '3.9'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2.4.0
+      - name: Setup Python
+        uses: actions/setup-python@v2.3.0
+        with:
+          python-version: ${{matrix.python-version}}
+
+      # Create cache so that we don't have to do this for each step in the matrix.
+      - name: Create cache for Poetry
+        id: cache-poetry
+        uses: actions/cache@v2.1.6
+        with:
+          path: ~/.poetry
+          key: ${{ matrix.os }}-poetry
+
+      # Install latest Poetry if cache has changed.
+      - name: Install latest version of Poetry
+        if: steps.cache-poetry.outputs.cache-hit != 'true'
+        run: |
+          curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python -
+
+      # Add Poetry to github_path
+      - name: Add Poetry to $PATH
+        run: |
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+
+      - name: Get Poetry version
+        run: poetry --version
+
+      - name: Check pyproject.toml validity
+        run: poetry check --no-interaction
+
+      - name: Cache dependencies
+        id: cache-deps
+        uses: actions/cache@v2.1.6
+        with:
+          path: ${{github.workspace}}/.venv
+          key: ${{ matrix.os }}-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: ${{ matrix.os }}-
+
+      - name: Install deps
+        if: steps.cache-deps.cache-hit != 'true'
+        run: |
+          poetry config virtualenvs.in-project true
+          poetry install --no-interaction
+
+      - name: Run tests
+        run: poetry run pytest -v
+
+      - name: Build artifacts
+        run: poetry build

--- a/.github/workflows/cbc-optimizer-ci.yml
+++ b/.github/workflows/cbc-optimizer-ci.yml
@@ -18,6 +18,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Build Dockerfile
-        run: docker build --pull -t oogeso --target dev -f Dockerfile .
+        run: docker build --pull -t oogeso --target test -f Dockerfile .
       - name: Test cbc
         run: docker run --rm oogeso bash -c "poetry run pytest"

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,5 @@
+v0.3_2021-11
+-initial package publish on PyPi
 v0.2_2020-11
 -complete model
 v0.1_2020-05-11

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.8 as dev
+FROM python:3.9 as dev
 
 ARG INSTALL_DEV=true
 ENV PYTHONUNBUFFERED=1
@@ -22,16 +22,15 @@ COPY pyproject.toml poetry.lock ./
 
 RUN pip install poetry && poetry config virtualenvs.create false
 
-WORKDIR /code
+RUN bash -c "if [ $INSTALL_DEV == 'true' ] ; then poetry install --no-root ; else poetry install --no-root --no-dev ; fi"
 
-COPY pyproject.toml poetry.lock ./
-
-RUN bash -c "if [ INSTALL_DEV == 'true' ] ; then poetry install --no-root ; else poetry install --no-root --no-dev ; fi"
-
-ENV PYTHONPATH=/code
-
-FROM dev AS build
+FROM dev as test
 
 COPY ./ ./
+ENV PYTHONPATH=/code/src
+
+FROM test AS build
 
 RUN poetry install --no-dev
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,20 @@
-FROM python:3.9 as dev
+FROM python:3.9.8 as dev
+
+ARG INSTALL_DEV=true
+ENV PYTHONUNBUFFERED=1
 
 RUN apt-get update && \
   apt-get -y upgrade && \
   rm -rf /var/lib/apt/lists/* \
 
-ARG INSTALL_DEV=false
-ENV PYTHONUNBUFFERED=1
+WORKDIR /coinbrew
+
+# Download repository with CBC solver and intstall
+RUN git clone https://github.com/coin-or/coinbrew /var/cbc
+WORKDIR /var/cbc
+RUN ./coinbrew fetch Cbc:stable/2.10 --no-prompt --no-third-party
+RUN ./coinbrew build Cbc --no-prompt --no-third-party --prefix=/usr
+ENV COIN_INSTALL_DIR /usr
 
 WORKDIR /code
 
@@ -21,7 +30,7 @@ RUN bash -c "if [ INSTALL_DEV == 'true' ] ; then poetry install --no-root ; else
 
 ENV PYTHONPATH=/code
 
-FROM build AS tests
+FROM dev AS build
 
 COPY ./ ./
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "astroid"
-version = "2.8.5"
+version = "2.9.0"
 description = "An abstract syntax tree for Python with inference support."
 category = "dev"
 optional = false
@@ -89,7 +89,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "fonttools"
-version = "4.28.1"
+version = "4.28.2"
 description = "Tools to manipulate font files"
 category = "main"
 optional = true
@@ -365,19 +365,19 @@ pyparsing = ">=2.1.4"
 
 [[package]]
 name = "pylint"
-version = "2.11.1"
+version = "2.12.1"
 description = "python code static checker"
 category = "dev"
 optional = false
-python-versions = "~=3.6"
+python-versions = ">=3.6.2"
 
 [package.dependencies]
-astroid = ">=2.8.0,<2.9"
+astroid = ">=2.9.0,<2.10"
 colorama = {version = "*", markers = "sys_platform == \"win32\""}
 isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.7"
 platformdirs = ">=2.2.0"
-toml = ">=0.7.1"
+toml = ">=0.9.2"
 typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""}
 
 [[package]]
@@ -466,7 +466,7 @@ python-versions = "*"
 
 [[package]]
 name = "scipy"
-version = "1.7.2"
+version = "1.7.3"
 description = "SciPy: Scientific Library for Python"
 category = "main"
 optional = false
@@ -611,8 +611,8 @@ content-hash = "7c57b60a2e108301bd179b6ef573f3b591dd5690e32a083d0ec46bc3f66f7249
 
 [metadata.files]
 astroid = [
-    {file = "astroid-2.8.5-py3-none-any.whl", hash = "sha256:abc423a1e85bc1553954a14f2053473d2b7f8baf32eae62a328be24f436b5107"},
-    {file = "astroid-2.8.5.tar.gz", hash = "sha256:11f7356737b624c42e21e71fe85eea6875cb94c03c82ac76bd535a0ff10b0f25"},
+    {file = "astroid-2.9.0-py3-none-any.whl", hash = "sha256:776ca0b748b4ad69c00bfe0fff38fa2d21c338e12c84aa9715ee0d473c422778"},
+    {file = "astroid-2.9.0.tar.gz", hash = "sha256:5939cf55de24b92bda00345d4d0659d01b3c7dafb5055165c330bc7c568ba273"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -639,8 +639,8 @@ cycler = [
     {file = "cycler-0.11.0.tar.gz", hash = "sha256:9c87405839a19696e837b3b818fed3f5f69f16f1eec1a1ad77e043dcea9c772f"},
 ]
 fonttools = [
-    {file = "fonttools-4.28.1-py3-none-any.whl", hash = "sha256:68071406009e7ef6a5fdcd85d95975cd6963867bb226f2b786bfffe15d1959ef"},
-    {file = "fonttools-4.28.1.zip", hash = "sha256:8c8f84131bf04f3b1dcf99b9763cec35c347164ab6ad006e18d2f99fcab05529"},
+    {file = "fonttools-4.28.2-py3-none-any.whl", hash = "sha256:eff1da7ea274c54cb8842853005a139f711646cbf6f1bcfb6c9b86a627f35ff0"},
+    {file = "fonttools-4.28.2.zip", hash = "sha256:dca694331af74c8ad47acc5171e57f6b78fac5692bf050f2ab572964577ac0dd"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-4.8.2-py3-none-any.whl", hash = "sha256:53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100"},
@@ -970,8 +970,8 @@ pydot = [
     {file = "pydot-1.4.2.tar.gz", hash = "sha256:248081a39bcb56784deb018977e428605c1c758f10897a339fce1dd728ff007d"},
 ]
 pylint = [
-    {file = "pylint-2.11.1-py3-none-any.whl", hash = "sha256:0f358e221c45cbd4dad2a1e4b883e75d28acdcccd29d40c76eb72b307269b126"},
-    {file = "pylint-2.11.1.tar.gz", hash = "sha256:2c9843fff1a88ca0ad98a256806c82c5a8f86086e7ccbdb93297d86c3f90c436"},
+    {file = "pylint-2.12.1-py3-none-any.whl", hash = "sha256:b4b5a7b6d04e914a11c198c816042af1fb2d3cda29bb0c98a9c637010da2a5c5"},
+    {file = "pylint-2.12.1.tar.gz", hash = "sha256:4f4a52b132c05b49094b28e109febcec6bfb7bc6961c7485a5ad0a0f961df289"},
 ]
 pyomo = [
     {file = "Pyomo-6.2-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:78f0c148772a9fcce77c39b37e5ec4c191b8fbdb74b79eea96185446bc2df92c"},
@@ -1091,29 +1091,32 @@ regex = [
     {file = "regex-2021.11.10.tar.gz", hash = "sha256:f341ee2df0999bfdf7a95e448075effe0db212a59387de1a70690e4acb03d4c6"},
 ]
 scipy = [
-    {file = "scipy-1.7.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:97eb573e361a73a553b915dc195c6f72a08249964b1a33f157f9659f3b6210d1"},
-    {file = "scipy-1.7.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:359b60a0cccd17723b9d5e329a5212a710e771a3ddde800e472fb93732756c46"},
-    {file = "scipy-1.7.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82c5befebf54d799d77e5f0205c03030f57f69ba2541baa44d2e6ad138c28cd3"},
-    {file = "scipy-1.7.2-cp310-cp310-win_amd64.whl", hash = "sha256:54951f51d731c832b1b8885e0a92e89f33d087de7e40d02078bf0d49c7cbdbb5"},
-    {file = "scipy-1.7.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:30bdda199667e74b50208a793eb1ba47a04e5e3fa16f5ff06c6f7969ae78e4da"},
-    {file = "scipy-1.7.2-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:e3efe7ef75dfe627b354ab0af0dbc918eadee97cc80ff1aabea6d3e01114ebdd"},
-    {file = "scipy-1.7.2-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:17fd991a275e4283453f89d404209aa92059ac68d76d804b4bc1716a3742e1b5"},
-    {file = "scipy-1.7.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:74f518ce542533054695f743e4271cb8986b63f95bb51d70fcee4f3929cbff7d"},
-    {file = "scipy-1.7.2-cp37-cp37m-win32.whl", hash = "sha256:1437073f1d4664990879aa8f9547524764372e0fef84a077be4b19e82bba7a8d"},
-    {file = "scipy-1.7.2-cp37-cp37m-win_amd64.whl", hash = "sha256:39f838ea5ce8da868785193d88d05cf5a6d5c390804ec99de29a28e1dcdd53e6"},
-    {file = "scipy-1.7.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e08b81fcd9bf98740b58dc6fdd7879e33a64dcb682201c1135f7d4a75216bb05"},
-    {file = "scipy-1.7.2-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:7b1d0f5f524518f1a86f288443528e4ff4a739c0966db663af4129b7ac7849f8"},
-    {file = "scipy-1.7.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cac71d5476a6f56b50459da21f6221707e0051ebd428b2137db32ef4a43bb15e"},
-    {file = "scipy-1.7.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4d175ba93e00d8eef8f7cd70d4d88a9106a86800c82ea03cf2268c36d6545483"},
-    {file = "scipy-1.7.2-cp38-cp38-win32.whl", hash = "sha256:8b5726a0fedeaa6beb1095e4466998bdd1d1e960b28db9b5a16c89cbd7b2ebf1"},
-    {file = "scipy-1.7.2-cp38-cp38-win_amd64.whl", hash = "sha256:8482c8e45857ab0a5446eb7460d2307a27cbbe659d6d2257820c6d6eb950fd0f"},
-    {file = "scipy-1.7.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1ea6233f5a365cb7945b4304bd06323ece3ece85d6a3fa8598d2f53e513467c9"},
-    {file = "scipy-1.7.2-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:d86abd1ddf421dea5e9cebfeb4de0d205b3dc04e78249afedba9c6c3b2227ff2"},
-    {file = "scipy-1.7.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2d25272c03ee3c0fe5e0dff1bb7889280bb6c9e1766fa9c7bde81ad8a5f78694"},
-    {file = "scipy-1.7.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5273d832fb9cd5724ee0d335c16a903b923441107dd973d27fc4293075a9f4e3"},
-    {file = "scipy-1.7.2-cp39-cp39-win32.whl", hash = "sha256:87cf3964db0f1cce17aeed5bfc1b89a6b4b07dbfc48e50d21fa3549e00456803"},
-    {file = "scipy-1.7.2-cp39-cp39-win_amd64.whl", hash = "sha256:a80eb01c43fd98257ec7a49ff5cec0edba32031b5f86503f55399a48cb2c5379"},
-    {file = "scipy-1.7.2.tar.gz", hash = "sha256:fa2dbabaaecdb502641b0b3c00dec05fb475ae48655c66da16c9ed24eda1e711"},
+    {file = "scipy-1.7.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:173308efba2270dcd61cd45a30dfded6ec0085b4b6eb33b5eb11ab443005e088"},
+    {file = "scipy-1.7.3-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:21b66200cf44b1c3e86495e3a436fc7a26608f92b8d43d344457c54f1c024cbc"},
+    {file = "scipy-1.7.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ceebc3c4f6a109777c0053dfa0282fddb8893eddfb0d598574acfb734a926168"},
+    {file = "scipy-1.7.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f7eaea089345a35130bc9a39b89ec1ff69c208efa97b3f8b25ea5d4c41d88094"},
+    {file = "scipy-1.7.3-cp310-cp310-win_amd64.whl", hash = "sha256:304dfaa7146cffdb75fbf6bb7c190fd7688795389ad060b970269c8576d038e9"},
+    {file = "scipy-1.7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:033ce76ed4e9f62923e1f8124f7e2b0800db533828c853b402c7eec6e9465d80"},
+    {file = "scipy-1.7.3-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:4d242d13206ca4302d83d8a6388c9dfce49fc48fdd3c20efad89ba12f785bf9e"},
+    {file = "scipy-1.7.3-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8499d9dd1459dc0d0fe68db0832c3d5fc1361ae8e13d05e6849b358dc3f2c279"},
+    {file = "scipy-1.7.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca36e7d9430f7481fc7d11e015ae16fbd5575615a8e9060538104778be84addf"},
+    {file = "scipy-1.7.3-cp37-cp37m-win32.whl", hash = "sha256:e2c036492e673aad1b7b0d0ccdc0cb30a968353d2c4bf92ac8e73509e1bf212c"},
+    {file = "scipy-1.7.3-cp37-cp37m-win_amd64.whl", hash = "sha256:866ada14a95b083dd727a845a764cf95dd13ba3dc69a16b99038001b05439709"},
+    {file = "scipy-1.7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:65bd52bf55f9a1071398557394203d881384d27b9c2cad7df9a027170aeaef93"},
+    {file = "scipy-1.7.3-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:f99d206db1f1ae735a8192ab93bd6028f3a42f6fa08467d37a14eb96c9dd34a3"},
+    {file = "scipy-1.7.3-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:5f2cfc359379c56b3a41b17ebd024109b2049f878badc1e454f31418c3a18436"},
+    {file = "scipy-1.7.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eb7ae2c4dbdb3c9247e07acc532f91077ae6dbc40ad5bd5dca0bb5a176ee9bda"},
+    {file = "scipy-1.7.3-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95c2d250074cfa76715d58830579c64dff7354484b284c2b8b87e5a38321672c"},
+    {file = "scipy-1.7.3-cp38-cp38-win32.whl", hash = "sha256:87069cf875f0262a6e3187ab0f419f5b4280d3dcf4811ef9613c605f6e4dca95"},
+    {file = "scipy-1.7.3-cp38-cp38-win_amd64.whl", hash = "sha256:7edd9a311299a61e9919ea4192dd477395b50c014cdc1a1ac572d7c27e2207fa"},
+    {file = "scipy-1.7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:eef93a446114ac0193a7b714ce67659db80caf940f3232bad63f4c7a81bc18df"},
+    {file = "scipy-1.7.3-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:eb326658f9b73c07081300daba90a8746543b5ea177184daed26528273157294"},
+    {file = "scipy-1.7.3-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:93378f3d14fff07572392ce6a6a2ceb3a1f237733bd6dcb9eb6a2b29b0d19085"},
+    {file = "scipy-1.7.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edad1cf5b2ce1912c4d8ddad20e11d333165552aba262c882e28c78bbc09dbf6"},
+    {file = "scipy-1.7.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5d1cc2c19afe3b5a546ede7e6a44ce1ff52e443d12b231823268019f608b9b12"},
+    {file = "scipy-1.7.3-cp39-cp39-win32.whl", hash = "sha256:2c56b820d304dffcadbbb6cbfbc2e2c79ee46ea291db17e288e73cd3c64fefa9"},
+    {file = "scipy-1.7.3-cp39-cp39-win_amd64.whl", hash = "sha256:3f78181a153fa21c018d346f595edd648344751d7f03ab94b398be2ad083ed3e"},
+    {file = "scipy-1.7.3.tar.gz", hash = "sha256:ab5875facfdef77e0a47d5fd39ea178b58e60e454a4c85aa1e52fcb80db7babf"},
 ]
 seaborn = [
     {file = "seaborn-0.11.2-py3-none-any.whl", hash = "sha256:85a6baa9b55f81a0623abddc4a26b334653ff4c6b18c418361de19dbba0ef283"},

--- a/tests/test_cbc.py
+++ b/tests/test_cbc.py
@@ -1,0 +1,24 @@
+import pytest
+from pyomo import environ as pyo, opt as pyopt
+
+import oogeso
+from tests.test_testcase import TEST_DATA_ROOT_PATH
+
+
+def test_simulator_run():
+    data = oogeso.io.read_data_from_yaml(TEST_DATA_ROOT_PATH / "testdata1.yaml")
+    simulator = oogeso.Simulator(data)
+    # Continue test only if cbc executable is present
+    opt = pyo.SolverFactory("cbc")
+    if not opt.available():
+        pytest.skip("CBC executable not found. Skipping test")
+
+    sol = simulator.optimiser.solve(solver="cbc", timelimit=20)
+    assert (
+        sol.solver.termination_condition == pyopt.TerminationCondition.optimal
+    ), "Optimisation with CBC failed"
+    res = simulator.runSimulation("cbc", timerange=(0, 1), timelimit=20)
+    assert (
+        res.device_flow.loc[("dem", "el", "in", 0)]
+        == res.device_flow.loc[("source1", "el", "out", 0)]
+    )

--- a/tests/test_cbc.py
+++ b/tests/test_cbc.py
@@ -5,13 +5,12 @@ import oogeso
 from tests.test_testcase import TEST_DATA_ROOT_PATH
 
 
+@pytest.mark.skipif(not pyo.SolverFactory("cbc").available(), reason="Skipping test because CBC is not available.")
 def test_simulator_run():
     data = oogeso.io.read_data_from_yaml(TEST_DATA_ROOT_PATH / "testdata1.yaml")
     simulator = oogeso.Simulator(data)
     # Continue test only if cbc executable is present
     opt = pyo.SolverFactory("cbc")
-    if not opt.available():
-        pytest.skip("CBC executable not found. Skipping test")
 
     sol = simulator.optimiser.solve(solver="cbc", timelimit=20)
     assert (

--- a/tests/test_testcase.py
+++ b/tests/test_testcase.py
@@ -1,10 +1,6 @@
 from pathlib import Path
 import oogeso
 import oogeso.io
-import pyomo.opt as pyopt
-import pyomo.environ as pyo
-import pytest
-
 
 TEST_DATA_ROOT_PATH = Path(__file__).parent
 
@@ -16,22 +12,3 @@ def test_simulator_create():
     assert isinstance(simulator, oogeso.Simulator)
     assert isinstance(simulator.optimiser, oogeso.OptimisationModel)
     # assert isinstance(simulator.optimiser.pyomo_instance)
-
-
-def test_simulator_run():
-    data = oogeso.io.read_data_from_yaml(TEST_DATA_ROOT_PATH / "testdata1.yaml")
-    simulator = oogeso.Simulator(data)
-    # Continue test only if cbc executable is present
-    opt = pyo.SolverFactory("cbc")
-    if not opt.available():
-        pytest.skip("CBC executable not found. Skipping test")
-
-    sol = simulator.optimiser.solve(solver="cbc", timelimit=20)
-    assert (
-        sol.solver.termination_condition == pyopt.TerminationCondition.optimal
-    ), "Optimisation with CBC failed"
-    res = simulator.runSimulation("cbc", timerange=[0, 1], timelimit=20)
-    assert (
-        res.device_flow.loc[("dem", "el", "in", 0)]
-        == res.device_flow.loc[("source1", "el", "out", 0)]
-    )


### PR DESCRIPTION
### WHAT

Create CI pipeline that builds and runs CBC-optimizer tests

### WHY

To be able to build and test CBC-optimizer code that is normally a hazel to compile and install.

### HOW

Separate Dockerfile and GitHub Actions pipeline.

Unfortunately I was not able to find a PyPi native install for CBC.

### What to test/verify

Test needs to run.

---

### Contributor checklist

- [x] :tada: This PR closes #46.
- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] Task 1: Added new GitHub Actions pipeline
   - [x] Task 2: Updated Dockerfile to include CBC installation from coinbrew.
   - [x] Task 3: Modified test to run if CBC-solver is available. 
- [x] :page_with_curl: The following issues are related:
   - [x] #36 