### PR TITLE
adding options to provide solver excecutable and solver options

### DIFF
--- a/src/oogeso/core/optimiser.py
+++ b/src/oogeso/core/optimiser.py
@@ -47,10 +47,13 @@ class OptimisationModel:
         self._set_node_pressure_from_edge_data()
         self.pyomo_instance = self._create_pyomo_model(profiles_in_use)
 
-    def solve(self, solver="gurobi", write_yaml=False, time_limit=None):
+    def solve(self, solver="cbc", solver_executable=None, solver_options=None, write_yaml=False, time_limit=None):
         """Solve problem for planning horizon at a single timestep"""
 
-        opt = pyo.SolverFactory(solver)
+        opt = pyo.SolverFactory(solver, executable=solver_executable)
+        if solver_options is not None:
+            for k in solver_options:
+                opt.options[k] = solver_options[k]
         if time_limit is not None:
             if solver == "gurobi":
                 opt.options["TimeLimit"] = time_limit

--- a/src/oogeso/core/simulator.py
+++ b/src/oogeso/core/simulator.py
@@ -58,6 +58,8 @@ class Simulator:
     def run_simulation(
         self,
         solver: str,
+        solver_executable: Optional[str] = None,
+        solver_options: Optional[dict] = None,
         time_range: Tuple[int, int] = None,
         time_limit: Optional[int] = None,
         return_variables: Optional[Sequence[str]] = None,
@@ -69,7 +71,11 @@ class Simulator:
         Parameters
         ----------
         solver : string
-            Name of solver ("cbc", "gurobi")
+            Name of solver ("cbc", "gurobi", or others)
+        solver_executable : string
+            Path to executable
+        solver_options : dict
+            Solver-specific options passed on to solver (for fine-tuning performance)
         time_range : [int,int]
             Limit to this number of timesteps
         time_limit : int
@@ -135,7 +141,13 @@ class Simulator:
             # 1. Update problem formulation
             self.optimiser.updateOptimisationModel(step, first=first, profiles=self.profiles)
             # 2. Solve for planning horizon
-            self.optimiser.solve(solver=solver, write_yaml=write_yaml, time_limit=time_limit)
+            self.optimiser.solve(
+                solver=solver,
+                solver_executable=solver_executable,
+                solver_options=solver_options,
+                write_yaml=write_yaml,
+                time_limit=time_limit,
+            )
             # 3. Save results (for later analysis)
             new_results = self._save_optimisation_result(step, return_variables, store_duals)
             result_object.append_results(new_results)

--- a/tests/test_simulator.py
+++ b/tests/test_simulator.py
@@ -47,7 +47,7 @@ def test_simulator_create():
 def test_simulator_runsim():
     energy_system_data = _make_test_data()
     sim_obj = oogeso.Simulator(energy_system_data)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(Exception):
         sim_res = sim_obj.run_simulation(solver="wrong_solver_name", time_range=(0, 2))
 
     # single timestep:


### PR DESCRIPTION
# Pull Request

### WHAT

Add option to specify solver exectuable path and solver options

### WHY

More flexible than requiring solver to be found on the path. Specifying solver-specific options may be useful for fine-tuning in some cases.

### HOW

Additional optional arguments to the solve methods.

## Type of change

Please delete options that are not relevant.

- [x] DevOps, CI/CD

## What to test/verify

*Any specific way to test/verify the change? (ie an update to readme or other documentation would be sufficient)*

## Checklist:

- [x] :tada: This PR closes #69 .
- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGES.md`.
- [x] :books: I have considered updating the documentation in `README.md`, `userguide.md` or `docs/oogeso_manual.tex`.


