### PR TITLE
Fix: removed non-neccessary pyomo parameter giving runtime warning

### DIFF
--- a/src/oogeso/core/devices/source.py
+++ b/src/oogeso/core/devices/source.py
@@ -91,7 +91,7 @@ class PowerSource(Device):
         pw_y = lookup_table[1]
         var_x = pyomo_model.varDeviceFlow  # [self.dev_id, "el", "out", :]
         var_y = pyomo_model.varDevicePenalty  # [self.dev_id, "el", "out", :]
-        pw_repn = pyo.value(pyomo_model.paramPiecewiseRepn)
+        pw_repn = pyomo_model.optimisation_parameters.piecewise_repn
         constr_penalty = pyo.Piecewise(
             [self.id],
             ["el"],

--- a/src/oogeso/core/networks/network.py
+++ b/src/oogeso/core/networks/network.py
@@ -18,7 +18,7 @@ class Network:
         self.edges = edges
 
     def define_constraints(self, pyomo_model: pyo.Model):
-        piecewise_repn = pyo.value(pyomo_model.paramPiecewiseRepn)
+        piecewise_repn = pyomo_model.optimisation_parameters.piecewise_repn
         for edge in self.edges.values():
             edge.define_constraints(pyomo_model=pyomo_model, piecewise_repn=piecewise_repn)
 

--- a/src/oogeso/core/optimiser.py
+++ b/src/oogeso/core/optimiser.py
@@ -250,7 +250,6 @@ class OptimisationModel(pyo.ConcreteModel):
             within=pyo.Reals, default=self.optimisation_parameters.time_delta_minutes
         )
         self.paramTimeStorageReserveMinutes = pyo.Param(default=self.optimisation_parameters.time_reserve_minutes)
-        self.paramPiecewiseRepn = pyo.Param(within=pyo.Any, default=self.optimisation_parameters.piecewise_repn)
         self.paramMaxPressureDeviation = pyo.Param(
             within=pyo.Reals,
             default=self.optimisation_parameters.max_pressure_deviation,


### PR DESCRIPTION
# Pull Request

### WHAT

Removed parameter defintion

### WHY

Definition of pyomo model string parameter gives runtime warning. It is not necessary to define this as a pyomo model parameter

### HOW

Using normal python variable instead of Pyomo.Param to access the variable.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix - Requires bug fix version bump. e.g. from v1.0.0 to v1.0.1
- [x] DevOps, CI/CD

## What to test/verify

Existing tests should still run.

## Checklist:

- [ ] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `CHANGES.md`.
- [x] :books: I have considered updating the documentation in `README.md`, `userguide.md` or `docs/oogeso_manual.tex`.
