### PR TITLE
compute operating costs for selected time steps instead of entire hor…

### DIFF
--- a/src/oogeso/core/devices/base.py
+++ b/src/oogeso/core/devices/base.py
@@ -412,7 +412,7 @@ class Device(ABC):
         sum_cost = 0
         if self.dev_data.op_cost is not None:
             op_cost = self.dev_data.op_cost
-            for t in pyomo_model.setHorizon:
+            for t in timesteps:
                 var_P = self.get_flow_var(pyomo_model=pyomo_model, t=t)
                 sum_cost += op_cost * var_P
         # average per sec (simulation timestep drops out)

--- a/src/oogeso/core/optimiser.py
+++ b/src/oogeso/core/optimiser.py
@@ -594,7 +594,7 @@ class OptimisationModel(pyo.ConcreteModel):
         start_stop_costs = start_stop_costs / sum_time
         return start_stop_costs
 
-    def compute_operating_costs(self, model: pyo.Model):
+    def compute_operating_costs(self, model: pyo.Model, timesteps=None):
         """term in objective function to represent fuel costs or similar
         as average per sec ($/s)
 
@@ -602,17 +602,19 @@ class OptimisationModel(pyo.ConcreteModel):
         Note: el costs per MJ not per MWh
         """
         sum_cost = 0
-        timesteps = self.setHorizon
+        if timesteps is None:
+            timesteps = self.setHorizon
         for dev in self.setDevice:
             dev_obj = self.all_devices[dev]
             sum_cost += dev_obj.compute_operating_costs(model, timesteps)
         return sum_cost
 
-    def compute_cost_for_depleted_storage(self, model: pyo.Model):
+    def compute_cost_for_depleted_storage(self, model: pyo.Model, timesteps=None):
         """term in objective function to discourage depleting battery,
         making sure it is used only when required"""
         store_cost = 0
-        timesteps = self.setHorizon
+        if timesteps is None:
+            timesteps = self.setHorizon
         for dev in self.setDevice:
             dev_obj = self.all_devices[dev]
             store_cost += dev_obj.compute_cost_for_depleted_storage(model, timesteps)

--- a/tests/test_optimisation_model.py
+++ b/tests/test_optimisation_model.py
@@ -117,6 +117,22 @@ def test_optimiser_compute():
     assert export_revenue == 0
 
 
+def test_optimiser_methods(testcase2_data):
+    simulator = oogeso.Simulator(testcase2_data)
+    optimiser = simulator.optimiser
+
+    # check that the expression size (number of nodes in expression tree) is as expected:
+    co2_expr1 = optimiser.compute_CO2(model=optimiser, devices=None, timesteps=[0])
+    assert co2_expr1.size() == 10
+    co2_expr2 = optimiser.compute_CO2(model=optimiser)
+    assert co2_expr2.size() == 36
+
+    start_penalty1 = optimiser.compute_startup_penalty(model=optimiser, devices=None, timesteps=[0])
+    assert start_penalty1.size() == 12
+    start_penalty2 = optimiser.compute_startup_penalty(model=optimiser)
+    assert start_penalty2.size() == 36
+
+
 @pytest.mark.skipif(not pyo.SolverFactory("cbc").available(), reason="Skipping test because CBC is not available.")
 def test_optimisation_solve():
     """Check that it solves simple problem with CBC solver"""


### PR DESCRIPTION

# Pull Request

### WHAT

Correct bug in calculation of operating costs. This does not affect optimisation problem, but may affect plotting and other post-analyses.

### WHY

Inconsistent result. Bug.

### HOW

*A short description on why the chosen way (how) to solve the problem was chosen, if needed (ie, difficult to understand the solution, URLs used when solving the problem may be helpful)*

## Type of change

Please delete options that are not relevant.

- [x] Bug fix - Requires bug fix version bump. e.g. from v1.0.0 to v1.0.1

## What to test/verify

All tests should be unaffected.

## Checklist:

- [x] :tada: This PR closes #108 .
- [x] :scroll: I have broken down my PR into the following tasks:
   - [x] fix issue
- [x] :robot: I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR.
- [x] :book: I have considered adding a new entry in `docs/changelog.md`.
- [x] :books: I have considered updating the documentation in `README.md` or `docs/*.md` .

