### PR TITLE
Bumped isort version to fix pip-shims error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     hooks:
       - id: flake8
   - repo: https://github.com/timothycrosley/isort
-    rev: "5.10.1"
+    rev: "5.12.0"
     hooks:
       - id: isort
   - repo: https://github.com/PyCQA/bandit


### PR DESCRIPTION
Bumped isort version to fix pip-shims error

hydrogen profile class reference missing update

# Pull Request

## Type of change

- [x] Bug fix on branch

## What to test/verify
Runing the leogo reference platform with case C

## Checklist:
- [x] :tada: This PR closes #119 .