### PR TITLE
fix problem with datetime with new newer version of pandas

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
 ## Unpublished
+- Fix: Reading csv profile data with timestamp column
 
 ## v1.2.0
 2024-04-04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "oogeso"
-version = "1.2.0"
+version = "1.2.1"
 description = "Offshore Oil and Gas Field Energy System Operational Optimisation (OOGESO)"
 authors = ["Harald Svendsen <harald.svendsen@sintef.no>"]
 license = "MIT License (http://opensource.org/licenses/MIT)"

--- a/src/oogeso/io/file_io.py
+++ b/src/oogeso/io/file_io.py
@@ -122,18 +122,18 @@ def read_profiles_from_csv(
     df_profiles_forecast = pd.read_csv(
         filename_forecasts,
         index_col=timestamp_col,
-        parse_dates=[timestamp_col],
-        dayfirst=dayfirst,
         usecols=lambda col: col not in exclude_cols,
     )
+    if timestamp_col:
+        df_profiles_forecast.index = pd.to_datetime(df_profiles_forecast.index, dayfirst=dayfirst, format="mixed")
     df_profiles_nowcast = pd.DataFrame()  # empty dataframe
     if filename_nowcasts is not None:
         df_profiles_nowcast = pd.read_csv(
             filename_nowcasts,
             index_col=timestamp_col,
-            parse_dates=[timestamp_col],
-            dayfirst=dayfirst,
             usecols=lambda col: col not in exclude_cols,
         )
+        if timestamp_col:
+            df_profiles_nowcast.index = pd.to_datetime(df_profiles_nowcast.index, dayfirst=dayfirst, format="mixed")
 
     return {"forecast": df_profiles_forecast, "nowcast": df_profiles_nowcast}


### PR DESCRIPTION
# Pull Request

### WHAT

Bug fix

### WHY

Profiles read from csv files with timestamp column are not read properly

### HOW

Instead of infering date format (deprecated in newer versions of pandas), use pandas.to_datetime

## Type of change

Please delete options that are not relevant.

- [x] Bug fix - Requires bug fix version bump. e.g. from v1.0.0 to v1.0.1

## What to test/verify

Resampling input 

## Checklist:

- [x] :tada: This PR closes #132 .
- [x] :book: I have considered adding a new entry in `docs/changelog.md`.
